### PR TITLE
Stack safety for Identity and State and GenT

### DIFF
--- a/core/src/main/scala/hedgehog/predef/Identity.scala
+++ b/core/src/main/scala/hedgehog/predef/Identity.scala
@@ -41,11 +41,13 @@ object Identity {
       override def bind[A, B](fa: Identity[A])(f: A => Identity[B]): Identity[B] =
         Identity(f(fa.value).value)
 
-      // FIXME: This is not stack safe.
-      override def tailRecM[A, B](a: A)(f: A => Identity[Either[A, B]]): Identity[B] =
-        bind(f(a)) {
-          case Left(value) => tailRecM(value)(f)
-          case Right(value) => point(value)
-        }
+      override def tailRecM[A, B](a: A)(f: A => Identity[Either[A, B]]): Identity[B] = {
+        def loop(a: A): B =
+          f(a).value match {
+            case Left(a) => loop(a)
+            case Right(b) => b
+          }
+        Identity(loop(a))
+      }
     }
 }


### PR DESCRIPTION
The implementation for State comes from cats. I'm not sure the implementation of GenT is correct but it passes the current tests. Stitching the tree back together from the stack is likely where the bugs are. Note GenT#ap is still not stack safe.